### PR TITLE
explicitly export `"main" : "index.json"` to support importing from node versions <= 12.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "files": [
     "index.json"
   ],
+  "main": "index.json",
   "scripts": {
     "build": "node build.js"
   }


### PR DESCRIPTION
Node versions < 12.7 can't import non-`.js` files (such as `.json`)  that aren't explicitly exposed from the `package.json` using `"main"` or similar explicit export properties. 